### PR TITLE
Fix binary literal handling

### DIFF
--- a/src/js/features/es6/syntax/octalAndBinaryLiterals/binaryLiterals.js
+++ b/src/js/features/es6/syntax/octalAndBinaryLiterals/binaryLiterals.js
@@ -10,7 +10,7 @@ exports.type = TYPE
 exports.func = (node, parent) => {
   if (node.type === 'Literal' &&
       typeof node.value === 'number' &&
-      node.raw.toLowerCase().indexOf('b') > -1
+      node.raw.toLowerCase().indexOf('0b') === 0
   ) {
     return util.createFeature(node, TYPE)
   }

--- a/test/js-features/es6/syntax/octalAndBinaryLiterals.js
+++ b/test/js-features/es6/syntax/octalAndBinaryLiterals.js
@@ -2,6 +2,7 @@
 let octalLiterals = require('../../../../src/js/features/es6/syntax/octalAndBinaryLiterals/octalLiterals.js')
 let binaryLiterals = require('../../../../src/js/features/es6/syntax/octalAndBinaryLiterals/binaryLiterals.js')
 let featureTest = require('../../featureTest.js')
+let featureTestNotMatch = require('../../featureTestNotMatch.js')
 
 describe('Octal and Binary Literals Feature', function () {
   it('should find lowercase octal literal', function () {
@@ -22,5 +23,10 @@ describe('Octal and Binary Literals Feature', function () {
   it('should find uppercase octal literal', function () {
     let program = `0B01`
     featureTest(program, binaryLiterals)
+  })
+
+  it('should not find hex literal', function () {
+    let program = `0x0b`
+    featureTestNotMatch(program, binaryLiterals)
   })
 })

--- a/test/js-features/featureTestNotMatch.js
+++ b/test/js-features/featureTestNotMatch.js
@@ -1,0 +1,16 @@
+let assert = require('assert')
+let detect = require('../../src/js/detect.js')
+
+module.exports = function (program, feature) {
+  if (feature === undefined) {
+    throw new Error('Feature not defined.')
+  }
+
+  let foundFeatures = detect.withFeatures(program, [feature]).features
+
+  assert.strictEqual(false,
+    Object.keys(foundFeatures).some((key) => {
+      return key === feature.type
+    })
+  )
+}


### PR DESCRIPTION
- close #6
- 0xb is a valid ES5 hexadecimal literal.

I did't know how to test this case with `featureTest.js`, So I created a new test helper named `featureTestNotMatch.js`.